### PR TITLE
Fixed typo "delimeted" -> "delimited" in settings.html

### DIFF
--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -70,7 +70,7 @@
 					<label class="control-label col-xs-5">Watch List</label>
 					<form name="watchForm" ng-submit="updatewatchlist()" novalidate>
 						<!-- type="number" not supported except on mobile -->
-						<input class="col-xs-7" type="string" required ng-model="WatchList" placeholder="space-delimeted identifiers" ng-blur="updatewatchlist()" />
+						<input class="col-xs-7" type="string" required ng-model="WatchList" placeholder="space-delimited identifiers" ng-blur="updatewatchlist()" />
 					</form>
 				</div>
 				<div class="form-group reset-flow">


### PR DESCRIPTION
Love this project! Thanks for all the work!

I just noticed a tiny misspelling in the Configuration/Watch List default field contents on the Settings web page; thought I'd flag it for you. 

This fixes #271, which I just created. Progress! Progress?

Thanks again.
